### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Overlay containing experimental clang-musl profile and related ebuilds.
 
 ### Prequisite
   - A working gentoo/musl system.
-  - Self-hosted [clang](https://wiki.gentoo.org/wiki/Clang#Bootstrapping_the_Clang_toolchain) compiler
+  - Self-hosted [clang](https://wiki.gentoo.org/wiki/Clang#Bootstrapping_the_Clang_toolchain) compiler, with the default-libcxx USE flag enabled.
   - Some knowledge of compilers, linkers and gentoo's package manager `portage`.
 
 ### Installation


### PR DESCRIPTION
This is a very important detail when bootstrapping clang by following the Gentoo Wiki instructions.

Now I'm aware there is a stage3 available. However, it should only be mentioned after some official distribution mean is provided.