### PR TITLE
Create clang-musl-patchset-1-r1.ebuild

### DIFF
--- a/sys-base/clang-musl-patchset/clang-musl-patchset-1-r1.ebuild
+++ b/sys-base/clang-musl-patchset/clang-musl-patchset-1-r1.ebuild
@@ -4,24 +4,17 @@
 EAPI=8
 
 DESCRIPTION="Patches to fix issues related to the clang-musl overlay"
-HOMEPAGE="https://github.com/leonardohn/gentoo-patchset"
-SRC_URI="https://github.com/leonardohn/gentoo-patchset/archive/refs/heads/main.zip"
+HOMEPAGE="https://github.com/clang-musl-overlay/gentoo-patchset"
+HASH_COMMIT="90f2471dc53127d58e4c70c4385ec121aaee4494"
+SRC_URI="https://github.com/clang-musl-overlay/gentoo-patchset/archive/${HASH_COMMIT}.tar.gz -> ${P}.tar.gz"
 
 S="${WORKDIR}"
 
 LICENSE=""
 SLOT="0"
-KEYWORDS="amd64 ~amd64"
-
-pkg_setup() {
-        fetch ${SRC_URI}
-}
-
-src_unpack() {
-        unpack main.zip
-}
+KEYWORDS="~amd64 amd64"
 
 src_install() {
-        insinto /etc/portage/patches/
-        doins -r gentoo-patchset-main/*
+        insinto `portageq get_repo_path / gentoo`
+        doins -r gentoo-patchset-${HASH_COMMIT}/*
 }

--- a/sys-base/clang-musl-patchset/clang-musl-patchset-1-r1.ebuild
+++ b/sys-base/clang-musl-patchset/clang-musl-patchset-1-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Patches to fix issues related to the clang-musl overlay"
+HOMEPAGE="https://github.com/leonardohn/gentoo-patchset"
+SRC_URI="https://github.com/leonardohn/gentoo-patchset/archive/refs/heads/main.zip"
+
+S="${WORKDIR}"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="amd64 ~amd64"
+
+pkg_setup() {
+        fetch ${SRC_URI}
+}
+
+src_unpack() {
+        unpack main.zip
+}
+
+src_install() {
+        insinto /etc/portage/patches/
+        doins -r gentoo-patchset-main/*
+}


### PR DESCRIPTION
Ebuild para baixar o patchset de uma vez.