### PR TITLE
virtual/rust: add 1.63.0

### DIFF
--- a/virtual/rust/rust-1.63.0.ebuild
+++ b/virtual/rust/rust-1.63.0.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for Rust language compiler"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv ~s390 sparc x86"
+IUSE="rustfmt"
+
+BDEPEND=""
+RDEPEND="|| (
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+)"


### PR DESCRIPTION
**vritual/rust-1.621::gentoo** keeps the old version of rust, creating a new virtual/rust will fix it.