### PR TITLE
dev-lang/ghc: add -fPIC to cabal

### DIFF
--- a/dev-lang/ghc/files/ghc-9.0.2-enable-fPIC-cabal.patch
+++ b/dev-lang/ghc/files/ghc-9.0.2-enable-fPIC-cabal.patch
@@ -1,0 +1,13 @@
+diff --git a/libraries/Cabal/Cabal/Distribution/Simple/Program/GHC.hs b/libraries/Cabal/Cabal/Distribution/Simple/Program/GHC.hs
+index 4d64f76..f86e52f 100644
+--- a/libraries/Cabal/Cabal/Distribution/Simple/Program/GHC.hs
++++ b/libraries/Cabal/Cabal/Distribution/Simple/Program/GHC.hs
+@@ -581,7 +581,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
+        Nothing                 -> []
+        Just GhcModeCompile     -> ["-c"]
+        Just GhcModeLink        -> []
+-       Just GhcModeMake        -> ["--make"]
++       Just GhcModeMake        -> ["--make", "-fPIC"]
+        Just GhcModeInteractive -> ["--interactive"]
+        Just GhcModeAbiHash     -> ["--abi-hash"]
+ --     Just GhcModeDepAnalysis -> ["-M"]

--- a/dev-lang/ghc/ghc-9.0.2.ebuild
+++ b/dev-lang/ghc/ghc-9.0.2.ebuild
@@ -524,6 +524,8 @@ src_prepare() {
 		eapply "${FILESDIR}"/${PN}-8.10.1-allow-cross-bootstrap.patch
 		eapply "${FILESDIR}"/${PN}-9.0.2-disable-unboxed-arrays.patch
 		eapply "${FILESDIR}"/${PN}-9.0.2-llvm-14.patch
+		# Fixes 'relocation R_X86_64_32S cannot be used against local symbol; recompile with -fPIC'
+		eapply "${FILESDIR}"/${PN}-9.0.2-enable-fPIC-cabal.patch
 
 		# mingw32 target
 		pushd "${S}/libraries/Win32"


### PR DESCRIPTION
Enabling **-fPIC** by default in **cabal** for building libraries to avoid `relocation R_X86_64_32S cannot be used against local symbol; recompile with -fPIC` errors in static linking, for example in `xmonad --recompile`.
You needs to remerge **dev-lang/ghc**, and haskell packages via `haskell-updater -a`.