### PR TITLE
sys-devel/llvm: remove sys-devel/binutils dep

### DIFF
--- a/sys-devel/llvm/llvm-15.0.7.ebuild
+++ b/sys-devel/llvm/llvm-15.0.7.ebuild
@@ -24,7 +24,6 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	sys-libs/zlib:0=[${MULTILIB_USEDEP}]
-	binutils-plugin? ( >=sys-devel/binutils-2.31.1-r4:*[plugins] )
 	exegesis? ( dev-libs/libpfm:= )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=dev-libs/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )

--- a/sys-devel/llvm/llvm-16.0.0_rc3.ebuild
+++ b/sys-devel/llvm/llvm-16.0.0_rc3.ebuild
@@ -27,7 +27,6 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	sys-libs/zlib:0=[${MULTILIB_USEDEP}]
-	binutils-plugin? ( >=sys-devel/binutils-2.31.1-r4:*[plugins] )
 	exegesis? ( dev-libs/libpfm:= )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=dev-libs/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )

--- a/sys-devel/llvm/llvm-16.0.0_rc4.ebuild
+++ b/sys-devel/llvm/llvm-16.0.0_rc4.ebuild
@@ -27,7 +27,6 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	sys-libs/zlib:0=[${MULTILIB_USEDEP}]
-	binutils-plugin? ( >=sys-devel/binutils-2.31.1-r4:*[plugins] )
 	exegesis? ( dev-libs/libpfm:= )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=dev-libs/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )

--- a/sys-devel/llvm/llvm-17.0.0_pre20230304.ebuild
+++ b/sys-devel/llvm/llvm-17.0.0_pre20230304.ebuild
@@ -27,7 +27,6 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	sys-libs/zlib:0=[${MULTILIB_USEDEP}]
-	binutils-plugin? ( >=sys-devel/binutils-2.31.1-r4:*[plugins] )
 	exegesis? ( dev-libs/libpfm:= )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=dev-libs/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/899080
Merged into main repo in https://github.com/gentoo/gentoo/commit/0ef5d597cab485d25c7fcf9733a329daab4ad07e