### PR TITLE
sys-devel/llvm: Add dependencies for llvm-debuginfod

### DIFF
--- a/sys-devel/llvm/llvm-17.0.0_pre20230502.ebuild
+++ b/sys-devel/llvm/llvm-17.0.0_pre20230502.ebuild
@@ -20,13 +20,17 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA BSD public-domain rc"
 SLOT="${LLVM_MAJOR}/${LLVM_SOABI}"
 KEYWORDS=""
 IUSE="
-	+binutils-plugin debug doc exegesis libedit +libffi ncurses polly test xar
-	xml z3 zstd
+	+binutils-plugin debug debuginfod doc exegesis libedit +libffi
+	ncurses polly test xar xml z3 zstd
 "
 RESTRICT="!test? ( test )"
 
 RDEPEND="
 	sys-libs/zlib:0=[${MULTILIB_USEDEP}]
+	debuginfod? (
+		net-misc/curl:=
+		dev-cpp/cpp-httplib:=
+	)
 	exegesis? ( dev-libs/libpfm:= )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=dev-libs/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )
@@ -238,7 +242,6 @@ get_distribution_components() {
 			llvm-cxxfilt
 			llvm-cxxmap
 			llvm-debuginfo-analyzer
-			llvm-debuginfod
 			llvm-debuginfod-find
 			llvm-diff
 			llvm-dis
@@ -319,6 +322,9 @@ get_distribution_components() {
 		use binutils-plugin && out+=(
 			LLVMgold
 		)
+		use debuginfod && out+=(
+			llvm-debuginfod
+		)
 	fi
 
 	printf "%s${sep}" "${out[@]}"
@@ -360,6 +366,8 @@ multilib_src_configure() {
 		-DLLVM_ENABLE_LIBPFM=$(usex exegesis)
 		-DLLVM_ENABLE_Z3_SOLVER=$(usex z3)
 		-DLLVM_ENABLE_ZSTD=$(usex zstd)
+		-DLLVM_ENABLE_CURL=$(usex debuginfod)
+		-DLLVM_ENABLE_HTTPLIB=$(usex debuginfod)
 
 		-DLLVM_HOST_TRIPLE="${CHOST}"
 

--- a/sys-devel/llvm/llvm-17.0.0_pre20230512.ebuild
+++ b/sys-devel/llvm/llvm-17.0.0_pre20230512.ebuild
@@ -20,13 +20,17 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA BSD public-domain rc"
 SLOT="${LLVM_MAJOR}/${LLVM_SOABI}"
 KEYWORDS=""
 IUSE="
-	+binutils-plugin debug doc exegesis libedit +libffi ncurses polly test xar
-	xml z3 zstd
+	+binutils-plugin debug debuginfod doc exegesis libedit +libffi
+	ncurses polly test xar xml z3 zstd
 "
 RESTRICT="!test? ( test )"
 
 RDEPEND="
 	sys-libs/zlib:0=[${MULTILIB_USEDEP}]
+	debuginfod? (
+		net-misc/curl:=
+		dev-cpp/cpp-httplib:=
+	)
 	exegesis? ( dev-libs/libpfm:= )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=dev-libs/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )
@@ -238,7 +242,6 @@ get_distribution_components() {
 			llvm-cxxfilt
 			llvm-cxxmap
 			llvm-debuginfo-analyzer
-			llvm-debuginfod
 			llvm-debuginfod-find
 			llvm-diff
 			llvm-dis
@@ -319,6 +322,9 @@ get_distribution_components() {
 		use binutils-plugin && out+=(
 			LLVMgold
 		)
+		use debuginfod && out+=(
+			llvm-debuginfod
+		)
 	fi
 
 	printf "%s${sep}" "${out[@]}"
@@ -360,6 +366,8 @@ multilib_src_configure() {
 		-DLLVM_ENABLE_LIBPFM=$(usex exegesis)
 		-DLLVM_ENABLE_Z3_SOLVER=$(usex z3)
 		-DLLVM_ENABLE_ZSTD=$(usex zstd)
+		-DLLVM_ENABLE_CURL=$(usex debuginfod)
+		-DLLVM_ENABLE_HTTPLIB=$(usex debuginfod)
 
 		-DLLVM_HOST_TRIPLE="${CHOST}"
 

--- a/sys-devel/llvm/metadata.xml
+++ b/sys-devel/llvm/metadata.xml
@@ -11,6 +11,7 @@
 	4. LLVM does not imply things that you would expect from a high-level virtual machine. It does not require garbage collection or run-time code generation (In fact, LLVM makes a great static compiler!). Note that optional LLVM components can be used to build high-level virtual machines and other systems that need these services.</longdescription>
 	<use>
 		<flag name="binutils-plugin">Build the binutils plugin</flag>
+		<flag name="debuginfod">Install llvm-debuginfod (requires <pkg>net-misc/curl</pkg> and <pkg>dev-cpp/cpp-httplib</pkg>)</flag>
 		<flag name="doc">Build and install the HTML documentation and regenerate the man pages</flag>
 		<flag name="exegesis">Enable performance counter support for llvm-exegesis tool
 			that can be used to measure host machine instruction characteristics</flag>


### PR DESCRIPTION
Fixes https://github.com/clang-musl-overlay/clang-musl-overlay/issues/31
Merged into main repo in https://github.com/gentoo/gentoo/commit/b9ec9c5199f8ab0bd49585cf850243170fa081bf