### PR TITLE
sys-apps/musl-locales: update HOMEPAGE/EGIT_REPO_URI and metadata.xml

### DIFF
--- a/sys-apps/musl-locales/metadata.xml
+++ b/sys-apps/musl-locales/metadata.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-    <!-- maintainer-needed -->
+	<maintainer type="project">
+		<email>musl@gentoo.org</email>
+	</maintainer>
 </pkgmetadata>

--- a/sys-apps/musl-locales/musl-locales-9999.ebuild
+++ b/sys-apps/musl-locales/musl-locales-9999.ebuild
@@ -1,20 +1,23 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake git-r3
 
 DESCRIPTION="Locale program for musl libc"
-HOMEPAGE="https://gitlab.com/rilian-la-te/musl-locales"
-SRC_URI=""
-EGIT_REPO_URI="https://gitlab.com/rilian-la-te/musl-locales.git"
+HOMEPAGE="https://git.adelielinux.org/adelie/musl-locales"
+EGIT_REPO_URI="https://git.adelielinux.org/adelie/musl-locales.git"
 
 LICENSE="LGPL-3 MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
-IUSE=""
+KEYWORDS="~amd64"
 
-DEPEND=""
-RDEPEND="${DEPEND}"
-BDEPEND="sys-devel/gettext"
+RDEPEND="!sys-libs/glibc"
+
+src_configure() {
+	local mycmakeargs=(
+		-DLOCALE_PROFILE=OFF
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
Updates the live ebuild to upstream in gentoo tree ([musl-locales-0.1.0.ebuild](https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-apps/musl-locales/musl-locales-0.1.0.ebuild))