### PR TITLE
net-libs/nodejs-20.9.0: fixed dep on ninja (dev-util -> dev-build)

### DIFF
--- a/net-libs/nodejs/nodejs-20.9.0.ebuild
+++ b/net-libs/nodejs/nodejs-20.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,7 +42,7 @@ RDEPEND=">=app-arch/brotli-1.0.9:=
 	system-icu? ( >=dev-libs/icu-67:= )
 	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
 BDEPEND="${PYTHON_DEPS}
-	dev-util/ninja
+	dev-build/ninja
 	sys-apps/coreutils
 	virtual/pkgconfig
 	test? ( net-misc/curl )
@@ -247,7 +247,7 @@ src_test() {
 
 pkg_postinst() {
 	if use npm; then
-	    ewarn "remember to run: source /etc/profile if you plan to use nodejs"
+		ewarn "remember to run: source /etc/profile if you plan to use nodejs"
 		ewarn "	in your current shell"
 	fi
 }


### PR DESCRIPTION
smol fix since both cmake and ninja have been moved under the dev-build category